### PR TITLE
precompile line splitting regex

### DIFF
--- a/lib/byline.js
+++ b/lib/byline.js
@@ -21,6 +21,8 @@
 var stream = require('stream'),
     util = require('util');
     
+var splitting_re = /\r\n|\r|\n/g;
+
 // convinience API
 module.exports = function(readStream, options) {
   return module.exports.createStream(readStream, options);
@@ -94,7 +96,7 @@ LineStream.prototype._transform = function(chunk, encoding, done) {
   }
   this._chunkEncoding = encoding;
   
-  var lines = chunk.split(/\r\n|\r|\n/g);
+  var lines = chunk.split(splitting_re);
   
   if (this._lineBuffer.length > 0) {
     this._lineBuffer[this._lineBuffer.length - 1] += lines[0];


### PR DESCRIPTION
precompiling regexp for performance reasons
@demmer @alfred-landrum 
